### PR TITLE
Disable GenerateTargetFrameworkAttribute to prevent duplicate defintions

### DIFF
--- a/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
+++ b/Lidgren.Network.MultiTarget/Lidgren.Network.MultiTarget.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net45;net46;net461;net462;net48;netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
     <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.1' or '$(TargetFramework)' == 'netcoreapp3.1'">$(DefineConstants);HAS_FULL_SPAN</DefineConstants>
   </PropertyGroup>
 


### PR DESCRIPTION
For cloning fresh on Windows, Lidgren.Network is autogenerating conflicting files

`C:\Users\Legionare\Documents\git\space-station-14\RobustToolbox\Lidgren.Network\Lidgren.Network\Lidgren.Network\obj\Release\.NETFramework,Version=v4.6.AssemblyAttributes.cs(4,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute [C:\Users\Legionare\Documents\git\space-station-14\RobustToolbox\Lidgren.Network\Lidgren.Network.csproj]`

`C:\Users\Legionare\Documents\git\space-station-14\RobustToolbox\Lidgren.Network\obj\Debug\netcoreapp3.1\.NETCoreApp,Version=v3.1.AssemblyAttributes.cs(4,12): error CS0579: Duplicate 'global::System.Runtime.Versioning.TargetFrameworkAttribute' attribute [C:\Users\Legionare\Documents\git\space-station-14\RobustToolbox\Lidgren.Network\Lidgren.Network.csproj]`

Adding `<GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>` prevents it from generating the first one.