### PR TITLE
Replace testing .NET 6/7/8 with 8/9/10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,11 +16,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Test .NET 6
-      # macOS images don't have .NET 6.
-      if: matrix.os != 'macos-latest'
-      run: dotnet test --configuration Release --framework net6.0 -v n
-    - name: Test .NET 7
-      run: dotnet test --configuration Release --framework net7.0 -v n
     - name: Test .NET 8
+      run: dotnet test --configuration Release --framework net8.0 -v n
+    - name: Test .NET 9
+      run: dotnet test --configuration Release --framework net8.0 -v n
+    - name: Test .NET 10
       run: dotnet test --configuration Release --framework net8.0 -v n

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,6 @@ jobs:
     - name: Test .NET 8
       run: dotnet test --configuration Release --framework net8.0 -v n
     - name: Test .NET 9
-      run: dotnet test --configuration Release --framework net8.0 -v n
+      run: dotnet test --configuration Release --framework net9.0 -v n
     - name: Test .NET 10
-      run: dotnet test --configuration Release --framework net8.0 -v n
+      run: dotnet test --configuration Release --framework net10.0 -v n

--- a/Lidgren.Network/NetUtility.Dns.cs
+++ b/Lidgren.Network/NetUtility.Dns.cs
@@ -299,17 +299,10 @@ namespace Lidgren.Network
 
 				return ResolveFilter(allowedFamily, addresses);
 			}
-			catch (SocketException ex)
+			catch (SocketException ex) when (IsNameResolutionFailure(ex))
 			{
-				if (ex.SocketErrorCode == SocketError.HostNotFound)
-				{
-					//LogWrite(string.Format(CultureInfo.InvariantCulture, "Failed to resolve host '{0}'.", ipOrHost));
-					return null;
-				}
-				else
-				{
-					throw;
-				}
+				//LogWrite(string.Format(CultureInfo.InvariantCulture, "Failed to resolve host '{0}'.", ipOrHost));
+				return null;
 			}
 
 		}
@@ -370,11 +363,16 @@ namespace Lidgren.Network
 
 				return ResolveFilter(allowedFamily, addresses);
 			}
-			catch (SocketException ex) when (ex.SocketErrorCode == SocketError.HostNotFound)
+			catch (SocketException ex) when (IsNameResolutionFailure(ex))
 			{
 				//LogWrite(string.Format(CultureInfo.InvariantCulture, "Failed to resolve host '{0}'.", ipOrHost));
 				return null;
 			}
+		}
+
+		private static bool IsNameResolutionFailure(SocketException ex)
+		{
+			return ex.SocketErrorCode == SocketError.HostNotFound || ex.SocketErrorCode == SocketError.NoData;
 		}
 
 		private static IPAddress? ResolveFilter(AddressFamily? allowedFamily, IPAddress[] addresses)

--- a/UnitTests/NetUtilityTests.cs
+++ b/UnitTests/NetUtilityTests.cs
@@ -56,13 +56,11 @@ namespace UnitTests
         }
 
         [Test]
-        [TestCase(AddressFamily.InterNetwork)]
-        [TestCase(AddressFamily.InterNetworkV6)]
-        public void TestResolveAllowed(AddressFamily family)
+        [TestCase(AddressFamily.InterNetwork, "127.0.0.1")]
+        [TestCase(AddressFamily.InterNetworkV6, "::1")]
+        public void TestResolveAllowed(AddressFamily family, string address)
         {
-	        IgnoreIfActions();
-	        
-            var addr = NetUtility.Resolve("example.com", family);
+            var addr = NetUtility.Resolve(address, family);
 
             Assert.That(addr?.AddressFamily, Is.EqualTo(family));
         }
@@ -93,13 +91,11 @@ namespace UnitTests
         }
 
         [Test]
-        [TestCase(AddressFamily.InterNetwork)]
-        [TestCase(AddressFamily.InterNetworkV6)]
-        public async Task TestResolveAsyncAllowed(AddressFamily family)
+        [TestCase(AddressFamily.InterNetwork, "127.0.0.1")]
+        [TestCase(AddressFamily.InterNetworkV6, "::1")]
+        public async Task TestResolveAsyncAllowed(AddressFamily family, string address)
         {
-	        IgnoreIfActions();
-         
-	        var addr = await NetUtility.ResolveAsync("example.com", family);
+	        var addr = await NetUtility.ResolveAsync(address, family);
 
             Assert.That(addr?.AddressFamily, Is.EqualTo(family));
         }
@@ -125,11 +121,5 @@ namespace UnitTests
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        private static void IgnoreIfActions()
-        {
-	        // https://github.com/actions/virtual-environments/issues/668
-	        if (Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true")
-		        Assert.Ignore("GitHub Actions Runners do not support IPv6 and as such this test is disabled.");
-        }
     }
 }


### PR DESCRIPTION
If we want to test the first two we would need to install those manually on the workflow so it's not doing anything for those right now
See https://github.com/space-wizards/SpaceWizards.Lidgren.Network/actions/runs/28184171682/job/83481499180?pr=18