### PR TITLE
Validate ReadHeader

### DIFF
--- a/Lidgren.Network/NetFragmentationHelper.cs
+++ b/Lidgren.Network/NetFragmentationHelper.cs
@@ -79,6 +79,7 @@ namespace Lidgren.Network
 
 			for (int shift = 0; shift <= 28; shift += 7)
 			{
+				// Header out of the expected range so dump it.
 				if (ptr >= endPtr)
 					return false;
 
@@ -95,6 +96,7 @@ namespace Lidgren.Network
 				}
 			}
 
+			// If the header bytes are still going then dump it.
 			return false;
 		}
 

--- a/Lidgren.Network/NetFragmentationHelper.cs
+++ b/Lidgren.Network/NetFragmentationHelper.cs
@@ -50,65 +50,52 @@ namespace Lidgren.Network
 			return ptr;
 		}
 
-		internal static int ReadHeader(byte[] buffer, int ptr, out int group, out int totalBits, out int chunkByteSize, out int chunkNumber)
+		internal static bool TryReadHeader(
+			byte[] buffer,
+			int ptr,
+			int endPtr,
+			out int headerEnd,
+			out int group,
+			out int totalBits,
+			out int chunkByteSize,
+			out int chunkNumber)
 		{
-			int num1 = 0;
-			int num2 = 0;
-			while (true)
+			headerEnd = ptr;
+			group = 0;
+			totalBits = 0;
+			chunkByteSize = 0;
+			chunkNumber = 0;
+
+			return TryReadVariableInt(buffer, ref headerEnd, endPtr, out group)
+				&& TryReadVariableInt(buffer, ref headerEnd, endPtr, out totalBits)
+				&& TryReadVariableInt(buffer, ref headerEnd, endPtr, out chunkByteSize)
+				&& TryReadVariableInt(buffer, ref headerEnd, endPtr, out chunkNumber);
+		}
+
+		private static bool TryReadVariableInt(byte[] buffer, ref int ptr, int endPtr, out int value)
+		{
+			uint result = 0;
+			value = 0;
+
+			for (int shift = 0; shift <= 28; shift += 7)
 			{
-				byte num3 = buffer[ptr++];
-				num1 |= (num3 & 0x7f) << (num2 & 0x1f);
-				num2 += 7;
-				if ((num3 & 0x80) == 0)
+				if (ptr >= endPtr)
+					return false;
+
+				byte next = buffer[ptr++];
+				result |= (uint)(next & 0x7f) << shift;
+
+				if ((next & 0x80) == 0)
 				{
-					group = num1;
-					break;
+					if (result > int.MaxValue)
+						return false;
+
+					value = (int)result;
+					return true;
 				}
 			}
 
-			num1 = 0;
-			num2 = 0;
-			while (true)
-			{
-				byte num3 = buffer[ptr++];
-				num1 |= (num3 & 0x7f) << (num2 & 0x1f);
-				num2 += 7;
-				if ((num3 & 0x80) == 0)
-				{
-					totalBits = num1;
-					break;
-				}
-			}
-
-			num1 = 0;
-			num2 = 0;
-			while (true)
-			{
-				byte num3 = buffer[ptr++];
-				num1 |= (num3 & 0x7f) << (num2 & 0x1f);
-				num2 += 7;
-				if ((num3 & 0x80) == 0)
-				{
-					chunkByteSize = num1;
-					break;
-				}
-			}
-
-			num1 = 0;
-			num2 = 0;
-			while (true)
-			{
-				byte num3 = buffer[ptr++];
-				num1 |= (num3 & 0x7f) << (num2 & 0x1f);
-				num2 += 7;
-				if ((num3 & 0x80) == 0)
-				{
-					chunkNumber = num1;
-					break;
-				}
-			}
-
-			return ptr;
+			return false;
 		}
 
 		internal static int GetFragmentationHeaderSize(int groupId, int totalBytes, int chunkByteSize, int numChunks)

--- a/Lidgren.Network/NetPeer.Fragmentation.cs
+++ b/Lidgren.Network/NetPeer.Fragmentation.cs
@@ -99,6 +99,8 @@ namespace Lidgren.Network
 			NetException.Assert(totalBits > 0);
 			NetException.Assert(chunkByteSize > 0);
 
+			// Last-minute sanity check.
+			// Probably not needed?
 			if (group <= 0
 				|| totalBits <= 0
 				|| chunkByteSize <= 0

--- a/Lidgren.Network/NetPeer.Fragmentation.cs
+++ b/Lidgren.Network/NetPeer.Fragmentation.cs
@@ -79,21 +79,37 @@ namespace Lidgren.Network
 			//
 			// read fragmentation header and combine fragments
 			//
-			int ptr = NetFragmentationHelper.ReadHeader(
-				im.Data, 0,
+			if (!NetFragmentationHelper.TryReadHeader(
+				im.Data, 0, im.LengthBytes,
+				out int ptr,
 				out int group,
 				out int totalBits,
 				out int chunkByteSize,
 				out int chunkNumber
-			);
+			))
+			{
+				LogWarning($"Dropping malformed fragment header from {im.SenderEndPoint}");
+				Recycle(im);
+				return;
+			}
 
 			NetException.Assert(im.LengthBytes > ptr);
 
 			NetException.Assert(group > 0);
 			NetException.Assert(totalBits > 0);
 			NetException.Assert(chunkByteSize > 0);
-			
-			int totalBytes = NetUtility.BytesToHoldBits((int)totalBits);
+
+			if (group <= 0
+				|| totalBits <= 0
+				|| chunkByteSize <= 0
+				|| ptr >= im.LengthBytes)
+			{
+				LogWarning($"Dropping malformed fragment from {im.SenderEndPoint} (group={group}, totalBits={totalBits}, chunkByteSize={chunkByteSize})");
+				Recycle(im);
+				return;
+			}
+
+			int totalBytes = NetUtility.BytesToHoldBits(totalBits);
 			int totalNumChunks = totalBytes / chunkByteSize;
 			if (totalNumChunks * chunkByteSize < totalBytes)
 				totalNumChunks++;
@@ -103,6 +119,7 @@ namespace Lidgren.Network
 			if (chunkNumber >= totalNumChunks)
 			{
 				LogWarning($"Index out of bounds for chunk {chunkNumber} (total chunks {totalNumChunks})");
+				Recycle(im);
 				return;
 			}
 

--- a/UnitTests/NetFragmentationHelperTests.cs
+++ b/UnitTests/NetFragmentationHelperTests.cs
@@ -1,0 +1,129 @@
+using Lidgren.Network;
+using NUnit.Framework;
+using System.Reflection;
+
+namespace UnitTests;
+
+[TestFixture]
+[TestOf(typeof(NetFragmentationHelper))]
+public sealed class NetFragmentationHelperTests
+{
+	[Test]
+	public void TryReadHeaderReadsValidHeader()
+	{
+		var buffer = new byte[32];
+		var end = NetFragmentationHelper.WriteHeader(buffer, 0, 7, 4096, 512, 3);
+
+		var ok = TryReadHeader(
+			buffer, 0, end,
+			out var headerEnd,
+			out var group,
+			out var totalBits,
+			out var chunkByteSize,
+			out var chunkNumber);
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(ok, Is.True);
+			Assert.That(headerEnd, Is.EqualTo(end));
+			Assert.That(group, Is.EqualTo(7));
+			Assert.That(totalBits, Is.EqualTo(4096));
+			Assert.That(chunkByteSize, Is.EqualTo(512));
+			Assert.That(chunkNumber, Is.EqualTo(3));
+		});
+	}
+
+	[Test]
+	public void TryReadHeaderRejectsTruncatedVarint()
+	{
+		var buffer = new byte[] { 1, 0x80 };
+
+		var ok = TryReadHeader(
+			buffer, 0, buffer.Length,
+			out _,
+			out _,
+			out _,
+			out _,
+			out _);
+
+		Assert.That(ok, Is.False);
+	}
+
+	[Test]
+	public void TryReadHeaderRejectsTooLong()
+	{
+		var buffer = new byte[] { 0x80, 0x80, 0x80, 0x80, 0x80 };
+
+		var ok = TryReadHeader(
+			buffer, 0, buffer.Length,
+			out _,
+			out _,
+			out _,
+			out _,
+			out _);
+
+		Assert.That(ok, Is.False);
+	}
+
+	[Test]
+	public void TryReadHeaderRejectsIntOverflow()
+	{
+		var buffer = new byte[] { 0xff, 0xff, 0xff, 0xff, 0x7f };
+
+		var ok = TryReadHeader(
+			buffer, 0, buffer.Length,
+			out _,
+			out _,
+			out _,
+			out _,
+			out _);
+
+		Assert.That(ok, Is.False);
+	}
+
+	[Test]
+	public void TryReadHeaderDoesNotReadPastLogicalEnd()
+	{
+		var buffer = new byte[] { 1, 0x80, 0, 1, 0 };
+
+		var ok = TryReadHeader(
+			buffer, 0, 2,
+			out _,
+			out _,
+			out _,
+			out _,
+			out _);
+
+		Assert.That(ok, Is.False);
+	}
+
+	// Blursed code to read the actual private method without just copying the underlying code and not accounting for
+	// new changes.
+	private static bool TryReadHeader(
+		byte[] buffer,
+		int ptr,
+		int endPtr,
+		out int headerEnd,
+		out int group,
+		out int totalBits,
+		out int chunkByteSize,
+		out int chunkNumber)
+	{
+
+		var method = typeof(NetFragmentationHelper).GetMethod(
+			"TryReadHeader",
+			BindingFlags.Static | BindingFlags.NonPublic);
+
+		Assert.That(method, Is.Not.Null, "NetFragmentationHelper.TryReadHeader is missing.");
+
+		object?[] args = { buffer, ptr, endPtr, 0, 0, 0, 0, 0 };
+		var ok = (bool)method!.Invoke(null, args)!;
+
+		headerEnd = (int)args[3]!;
+		group = (int)args[4]!;
+		totalBits = (int)args[5]!;
+		chunkByteSize = (int)args[6]!;
+		chunkNumber = (int)args[7]!;
+		return ok;
+	}
+}


### PR DESCRIPTION
This will log the corrupted header instead of throwing later on. It will also make sure the message gets released properly.