### PR TITLE
Ensure packet parsing errors are recycled

### DIFF
--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -538,6 +538,9 @@ namespace Lidgren.Network
 					return;
 				}
 
+				NetIncomingMessage? msg = null;
+				bool messageReleased = false;
+
 				try
 				{
 					if (tp >= NetMessageType.LibraryError)
@@ -552,7 +555,7 @@ namespace Lidgren.Network
 						if (sender == null && !m_configuration.IsMessageTypeEnabled(NetIncomingMessageType.UnconnectedData))
 							return; // dropping unconnected message since it's not enabled
 
-						NetIncomingMessage msg = CreateIncomingMessage(NetIncomingMessageType.Data, payloadByteLength);
+						msg = CreateIncomingMessage(NetIncomingMessageType.Data, payloadByteLength);
 						msg.m_isFragment = isFragment;
 						msg.m_receiveTime = now;
 						msg.m_sequenceNumber = sequenceNumber;
@@ -569,11 +572,13 @@ namespace Lidgren.Network
 								// We're connected; but we can still send unconnected messages to this peer
 								msg.m_incomingMessageType = NetIncomingMessageType.UnconnectedData;
 								ReleaseMessage(msg);
+								messageReleased = true;
 							}
 							else
 							{
 								// connected application (non-library) message
 								sender.ReceivedMessage(msg);
+								messageReleased = true;
 							}
 						}
 						else
@@ -582,11 +587,15 @@ namespace Lidgren.Network
 							// unconnected application (non-library) message
 							msg.m_incomingMessageType = NetIncomingMessageType.UnconnectedData;
 							ReleaseMessage(msg);
+							messageReleased = true;
 						}
 					}
 				}
 				catch (Exception ex)
 				{
+					if (!messageReleased && msg?.m_data != null)
+						Recycle(msg);
+
 					LogError($"Packet parsing error: {ex.Message} from {(NetEndPoint)senderRemote}");
 				}
 				ptr += payloadByteLength;


### PR DESCRIPTION
If something like the (soon-to-be-old) ReadHeader throws or something else not covered this ensures the message is still getting recycled at the very least and avoids the allocation spam.