### PR TITLE
Allow rapid connection reason to be disabled

### DIFF
--- a/Lidgren.Network/NetPeer.Internal.cs
+++ b/Lidgren.Network/NetPeer.Internal.cs
@@ -773,10 +773,7 @@ namespace Lidgren.Network
 					int reservedSlots = m_handshakes.Count + m_connections.Count;
 					if (reservedSlots >= m_configuration.m_maximumConnections)
 					{
-						// server full
-						NetOutgoingMessage full = CreateMessage("Server full");
-						full.m_messageType = NetMessageType.Disconnect;
-						SendLibrary(full, senderEndPoint);
+						SendConnectionRejection("Server full", senderEndPoint);
 						return;
 					}
 
@@ -785,9 +782,7 @@ namespace Lidgren.Network
 					var conCount = m_ipConnectionCounts.GetValueOrDefault(ip);
 					if (conCount >= m_configuration.MaximumIpConnections)
 					{
-						var msg = CreateMessage("Too many connections from your network");
-						msg.m_messageType = NetMessageType.Disconnect;
-						SendLibrary(msg, senderEndPoint);
+						SendConnectionRejection("Too many connections from your network", senderEndPoint);
 						return;
 					}
 
@@ -802,9 +797,7 @@ namespace Lidgren.Network
 						// just drop the packets for bots or darwin award winners
 						if (times == m_configuration.MaximumRapidConnections)
 						{
-							var msg = CreateMessage("You are connecting too fast!");
-							msg.m_messageType = NetMessageType.Disconnect;
-							SendLibrary(msg, senderEndPoint);
+							SendConnectionRejection("You are connecting too fast!", senderEndPoint);
 						}
 						return;
 					}
@@ -825,6 +818,16 @@ namespace Lidgren.Network
 					LogWarning($"Received unhandled library message {tp} from {senderEndPoint}");
 					return;
 			}
+		}
+
+		private void SendConnectionRejection(string reason, NetEndPoint recipient)
+		{
+			if (!m_configuration.SendConnectionRejectionReasons)
+				return;
+
+			var msg = CreateMessage(reason);
+			msg.m_messageType = NetMessageType.Disconnect;
+			SendLibrary(msg, recipient);
 		}
 
 		internal void AcceptConnection(NetConnection conn)

--- a/Lidgren.Network/NetPeerConfiguration.cs
+++ b/Lidgren.Network/NetPeerConfiguration.cs
@@ -72,6 +72,7 @@ namespace Lidgren.Network
 		internal bool m_autoFlushSendQueue;
 		private NetUnreliableSizeBehaviour m_unreliableSizeBehaviour;
 		internal bool m_suppressUnreliableUnorderedAcks;
+		private bool m_sendConnectionRejectionReasons;
 
 		internal NetIncomingMessageType m_disabledTypes;
 		internal int m_port;
@@ -133,6 +134,7 @@ namespace Lidgren.Network
 			m_maximumHandshakeAttempts = 5;
 			m_autoFlushSendQueue = true;
 			m_suppressUnreliableUnorderedAcks = false;
+			m_sendConnectionRejectionReasons = false;
 
 			m_logRateLimiterEnabled = true;
 			m_logRateLimitTargets = NetLogRateLimitTarget.All;
@@ -248,6 +250,16 @@ namespace Lidgren.Network
 		/// The maximum number of times a single IP address is allowed to try connect, within the window of <see cref="RapidConnectionWindow"/>.
 		/// </summary>
 		public int MaximumRapidConnections = 3;
+
+		/// <summary>
+		/// Should we send a disconnect reason when the limit is hit.
+		/// Avoids the server trying to spam messages out.
+		/// </summary>
+		public bool SendConnectionRejectionReasons
+		{
+			get { return m_sendConnectionRejectionReasons; }
+			set { m_sendConnectionRejectionReasons = value; }
+		}
 
         /// <summary>
         /// How many seconds until connection count decays for <see cref="MaximumRapidConnections"/>.


### PR DESCRIPTION
In case you just want them to get dropped without responding with a message every time.