### PR TITLE
Limit fragment reassembly lifetime

### DIFF
--- a/Lidgren.Network/NetPeer.Fragmentation.cs
+++ b/Lidgren.Network/NetPeer.Fragmentation.cs
@@ -131,6 +131,8 @@ namespace Lidgren.Network
 			NetException.Assert(im.SenderConnection != null);
 
 			var groups = im.SenderConnection.m_receivedFragmentGroups;
+			double now = NetTime.Now;
+			ExpireFragmentGroups(groups, now);
 			if (!groups.TryGetValue(group, out var info))
 			{
 				// single fragment groups can't accumulate unbounded buffers
@@ -141,13 +143,21 @@ namespace Lidgren.Network
 					return;
 				}
 
+				if (GetTotalFragmentGroupBytes(groups) + totalBytes > m_configuration.m_maximumFragmentReassemblyBytesPerConnection)
+				{
+					LogRateLimitedWarning(NetLogRateLimitTarget.MalformedFragment, im.SenderEndPoint, $"Too much fragment reassembly data from {im.SenderEndPoint}; dropping fragment");
+					Recycle(im);
+					return;
+				}
+
 				info = new ReceivedFragmentGroup(
 					GetStorage(totalBytes),
 					new NetBitVector(totalNumChunks),
 					totalBytes,
 					totalBits,
 					chunkByteSize,
-					totalNumChunks);
+					totalNumChunks,
+					now);
 				groups[group] = info;
 			}
 			// The computed offset/copy and received chunk bit vector depend on this
@@ -162,8 +172,8 @@ namespace Lidgren.Network
 				return;
 			}
 
+			info.LastReceived = now;
 			info.ReceivedChunks[chunkNumber] = true;
-			//info.LastReceived = (float)NetTime.Now;
 
 			// copy to data
 			int offset = (chunkNumber * chunkByteSize);
@@ -193,6 +203,30 @@ namespace Lidgren.Network
 			}
 
 			return;
+		}
+
+		private void ExpireFragmentGroups(Dictionary<int, ReceivedFragmentGroup> groups, double now)
+		{
+			if (groups.Count == 0)
+				return;
+
+			double oldestAllowed = now - m_configuration.m_fragmentGroupTimeout;
+			foreach (var pair in new List<KeyValuePair<int, ReceivedFragmentGroup>>(groups))
+			{
+				if (pair.Value.LastReceived >= oldestAllowed)
+					continue;
+
+				Recycle(pair.Value.Data);
+				groups.Remove(pair.Key);
+			}
+		}
+
+		private static int GetTotalFragmentGroupBytes(Dictionary<int, ReceivedFragmentGroup> groups)
+		{
+			int total = 0;
+			foreach (var group in groups.Values)
+				total += group.TotalBytes;
+			return total;
 		}
 	}
 }

--- a/Lidgren.Network/NetPeer.ReceivedFragmentGroup.cs
+++ b/Lidgren.Network/NetPeer.ReceivedFragmentGroup.cs
@@ -4,15 +4,15 @@ public partial class NetPeer
 {
 	internal sealed class ReceivedFragmentGroup
 	{
-		//public float LastReceived;
 		public byte[] Data { get; }
 		public NetBitVector ReceivedChunks { get; }
 		public int TotalBytes { get; }
 		public int TotalBits { get; }
 		public int ChunkByteSize { get; }
 		public int TotalNumChunks { get; }
+		public double LastReceived { get; set; }
 
-		public ReceivedFragmentGroup(byte[] data, NetBitVector receivedChunks, int totalBytes, int totalBits, int chunkByteSize, int totalNumChunks)
+		public ReceivedFragmentGroup(byte[] data, NetBitVector receivedChunks, int totalBytes, int totalBits, int chunkByteSize, int totalNumChunks, double lastReceived)
 		{
 			Data = data;
 			ReceivedChunks = receivedChunks;
@@ -20,6 +20,7 @@ public partial class NetPeer
 			TotalBits = totalBits;
 			ChunkByteSize = chunkByteSize;
 			TotalNumChunks = totalNumChunks;
+			LastReceived = lastReceived;
 		}
 	}
 }

--- a/Lidgren.Network/NetPeerConfiguration.cs
+++ b/Lidgren.Network/NetPeerConfiguration.cs
@@ -97,6 +97,8 @@ namespace Lidgren.Network
 		internal bool m_autoExpandMTU;
 		internal float m_expandMTUFrequency;
 		internal int m_expandMTUFailAttempts;
+		internal int m_maximumFragmentReassemblyBytesPerConnection;
+		internal float m_fragmentGroupTimeout;
 
 		/// <summary>
 		/// NetPeerConfiguration constructor
@@ -144,6 +146,8 @@ namespace Lidgren.Network
 			m_autoExpandMTU = false;
 			m_expandMTUFrequency = 2.0f;
 			m_expandMTUFailAttempts = 5;
+			m_maximumFragmentReassemblyBytesPerConnection = 32 * 1024 * 1024;
+			m_fragmentGroupTimeout = 30.0f;
 			m_unreliableSizeBehaviour = NetUnreliableSizeBehaviour.IgnoreMTU;
 
 			m_loss = 0.0f;
@@ -587,6 +591,34 @@ namespace Lidgren.Network
 		{
 			get { return m_expandMTUFailAttempts; }
 			set { m_expandMTUFailAttempts = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the maximum bytes used by incomplete fragment groups for one connection.
+		/// </summary>
+		public int MaximumFragmentReassemblyBytesPerConnection
+		{
+			get { return m_maximumFragmentReassemblyBytesPerConnection; }
+			set
+			{
+				if (value < 1)
+					throw new NetException("MaximumFragmentReassemblyBytesPerConnection must be at least 1");
+				m_maximumFragmentReassemblyBytesPerConnection = value;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets how long an incomplete fragment group is kept alive, in seconds.
+		/// </summary>
+		public float FragmentGroupTimeout
+		{
+			get { return m_fragmentGroupTimeout; }
+			set
+			{
+				if (value <= 0.0f)
+					throw new NetException("FragmentGroupTimeout must be greater than zero");
+				m_fragmentGroupTimeout = value;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
I think this existed at some point based on info.lastreceived being commented out in a few places.

Right now it only blocks on maximum concurrent and not memory used.

Regardless hopefully it means DOS will slurp up less RAM if connected.